### PR TITLE
fix: reduce redundancy of grouping symbols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-alemat = "0.6.1"
+alemat = "0.7.0"
 
 [dev-dependencies]
 insta = "1.34.0"

--- a/src/lexer/keywords/operators.rs
+++ b/src/lexer/keywords/operators.rs
@@ -7,6 +7,7 @@ generate_impl!(
     Operators,
     "+" => Plus,
     "-" => Minus,
+    "'" => Prime,
     "*" | "cdot" => Dot,
     "**" | "ast" => Asterisk,
     "***" | "star" => Star,
@@ -50,6 +51,7 @@ impl From<Operator> for alemat::elements::Operator {
         match value {
             self::Operator::Plus => Operator::plus(),
             self::Operator::Minus => Operator::minus(),
+            self::Operator::Prime => Operator::from("'"),
             self::Operator::Dot => Operator::dot(),
             self::Operator::Asterisk => Operator::asterisk(),
             self::Operator::Star => Operator::star(),

--- a/src/lexer/keywords/others.rs
+++ b/src/lexer/keywords/others.rs
@@ -14,7 +14,6 @@ generate_impl!(
     Other,
     Others,
     "," => Comma,
-    "'" => Prime,
     "frac" => Fraction,
     "/" => ForwardSlash,
     "^" => Power,
@@ -71,7 +70,6 @@ impl From<Other> for Element {
     fn from(value: Other) -> Self {
         match value {
             Other::Comma => Operator::from(",").into(),
-            Other::Prime => Operator::from("'").into(),
             Other::ForwardSlash => Operator::from("/").into(),
             Other::Integral => Operator::integral().into(),
             Other::OIntegral => Operator::circle_integral().into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,11 @@ where
 
 /// Write an abstract syntax tree into the [`Writer`]. The resulting output is controlled by the
 /// implementation of passed in [`Writer`].
+///
+/// # Errors
+///
+/// The [`Writer`] may fail to write the mathml. In such case the error defined by the [`Writer`]
+/// implementation is returned.
 pub fn write_mathml<'w, W>(
     ascii_math: AsciiMath<'_>,
     writer: &'w mut W,
@@ -36,7 +41,7 @@ where
     Ok(writer)
 }
 
-/// Render the abstract syntax tree into a string of MathMl.
+/// Render the abstract syntax tree into a string of mathml.
 pub fn render_mathml(ascii_math: AsciiMath<'_>) -> String {
     let mathml = MathMl::from(ascii_math);
     mathml.render().expect("BufMathMlWriter does not fail.")

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -34,8 +34,8 @@ pub enum SimpleExpr {
 
     /// Intermediate expression is simply a wrapped [`Expression`].
     /// AsciiMath differs Expression and Intermediate expression, but in this implementation they
-    /// are the same. The top-level expression defined is AsciiMath is the [`AsciiMath`] iterator
-    /// that produces multiple [`Expression`]s.
+    /// are the same. The top-level expression defined in ascii math grammar is the [`AsciiMath`]
+    /// iterator that produces multiple [`Expression`]s.
     ///
     /// [`AsciiMath`]: crate::AsciiMath
     Interm(Box<Expression>),

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -296,27 +296,19 @@ impl IntoElements for Expression {
 
         let is_underover = self.interm.is_underover();
 
-        let inner = self.interm.into_elements();
-
-        if matches!((&self.subscript, &self.supscript), (None, None)) {
-            return inner.into_elements();
-        }
+        let inner = if self.is_scripted() {
+            self.interm.into_elements()
+        } else {
+            return self.interm.into_elements();
+        };
 
         let sub = self.subscript.map(|s| match s {
-            SimpleExpr::Grouping(grp) => grp
-                .ungroup()
-                .into_iter()
-                .map(IntoElements::into_elements)
-                .collect(),
+            SimpleExpr::Grouping(grp) => grp.ungroup_map(IntoElements::into_elements).collect(),
             _ => s.into_elements(),
         });
 
         let sup = self.supscript.map(|s| match s {
-            SimpleExpr::Grouping(grp) => grp
-                .ungroup()
-                .into_iter()
-                .map(IntoElements::into_elements)
-                .collect(),
+            SimpleExpr::Grouping(grp) => grp.ungroup_map(IntoElements::into_elements).collect(),
             _ => s.into_elements(),
         });
 

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -303,13 +303,21 @@ impl IntoElements for Expression {
         }
 
         let sub = self.subscript.map(|s| match s {
-            SimpleExpr::Grouping(grp) => SimpleExpr::Grouping(grp.ignored_parentheses()),
-            _ => s,
+            SimpleExpr::Grouping(grp) => grp
+                .ungroup()
+                .into_iter()
+                .map(IntoElements::into_elements)
+                .collect(),
+            _ => s.into_elements(),
         });
 
         let sup = self.supscript.map(|s| match s {
-            SimpleExpr::Grouping(grp) => SimpleExpr::Grouping(grp.ignored_parentheses()),
-            _ => s,
+            SimpleExpr::Grouping(grp) => grp
+                .ungroup()
+                .into_iter()
+                .map(IntoElements::into_elements)
+                .collect(),
+            _ => s.into_elements(),
         });
 
         if is_underover {

--- a/src/parser/grouping.rs
+++ b/src/parser/grouping.rs
@@ -40,6 +40,12 @@ impl GroupingExpr {
         self.expr
     }
 
+    /// Returns an iterator over the group of expression inside the grouping without the grouping
+    /// symbols and mapped by the given function.
+    pub(crate) fn ungroup_map<T>(self, f: impl FnMut(Expression) -> T) -> impl Iterator<Item = T> {
+        self.ungroup().into_iter().map(f)
+    }
+
     /// Checks whether the grouping contains any expressions.
     pub fn is_empty(&self) -> bool {
         self.expr.is_empty()

--- a/src/parser/grouping.rs
+++ b/src/parser/grouping.rs
@@ -35,6 +35,11 @@ impl GroupingExpr {
         }
     }
 
+    /// Returns the group of expressions inside the grouping without the grouping symbols.
+    pub fn ungroup(self) -> Vec<Expression> {
+        self.expr
+    }
+
     /// Checks whether the grouping contains any expressions.
     pub fn is_empty(&self) -> bool {
         self.expr.is_empty()

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,10 +17,7 @@ pub use unary::*;
 pub use var::*;
 
 use crate::{
-    lexer::{
-        keywords::{groupings::Grouping, others::Other},
-        Span, TokenIterator, TokenKind,
-    },
+    lexer::{keywords::others::Other, Span, TokenIterator, TokenKind},
     scanner::Symbols,
 };
 
@@ -140,7 +137,7 @@ impl<'s> AsciiMath<'s> {
         };
 
         let interm = Expression {
-            val: s_expr,
+            interm: s_expr,
             subscript,
             supscript,
         };
@@ -155,7 +152,6 @@ impl<'s> AsciiMath<'s> {
             if matches!(next_token.kind(), TokenKind::Other(Other::ForwardSlash)) {
                 // I/I case -> fraction
                 let numerator = interm;
-                let numer_span = numerator.span();
 
                 self.iter.next(); // skip '/' token
                 let denominator = self.parse_expr()?;
@@ -165,19 +161,27 @@ impl<'s> AsciiMath<'s> {
 
                 // treat intermediate expressions as parenthesised expressions passed to frac:
                 // a_b/c_d == (a_b)/(c_d) == frac{a_b}{c_d}
-                let numerator = SimpleExpr::Grouping(GroupingExpr {
-                    left_grouping: Grouping::OpenParen,
-                    right_grouping: Grouping::CloseParen,
-                    expr: vec![numerator],
-                    span: numer_span,
-                });
+                let numerator = if !numerator.is_scripted() {
+                    numerator.into_interm_with(|inner| match inner {
+                        SimpleExpr::Grouping(grp) => {
+                            SimpleExpr::Grouping(grp.ignored_parentheses())
+                        }
+                        _ => inner,
+                    })
+                } else {
+                    SimpleExpr::Interm(Box::new(numerator))
+                };
 
-                let denominator = SimpleExpr::Grouping(GroupingExpr {
-                    left_grouping: Grouping::OpenParen,
-                    right_grouping: Grouping::CloseParen,
-                    expr: vec![denominator],
-                    span: numerator.span(),
-                });
+                let denominator = if !denominator.is_scripted() {
+                    denominator.into_interm_with(|inner| match inner {
+                        SimpleExpr::Grouping(grp) => {
+                            SimpleExpr::Grouping(grp.ignored_parentheses())
+                        }
+                        _ => inner,
+                    })
+                } else {
+                    SimpleExpr::Interm(Box::new(denominator))
+                };
 
                 let binary = Binary {
                     kind: BinaryKind::Fraction,
@@ -187,7 +191,7 @@ impl<'s> AsciiMath<'s> {
                 };
 
                 return Some(Expression {
-                    val: SimpleExpr::Binary(binary),
+                    interm: SimpleExpr::Binary(binary),
                     subscript: None,
                     supscript: None,
                 });

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -161,26 +161,26 @@ impl<'s> AsciiMath<'s> {
 
                 // treat intermediate expressions as parenthesised expressions passed to frac:
                 // a_b/c_d == (a_b)/(c_d) == frac{a_b}{c_d}
-                let numerator = if !numerator.is_scripted() {
+                let numerator = if numerator.is_scripted() {
+                    SimpleExpr::Interm(Box::new(numerator))
+                } else {
                     numerator.into_interm_with(|inner| match inner {
                         SimpleExpr::Grouping(grp) => {
                             SimpleExpr::Grouping(grp.ignored_parentheses())
                         }
                         _ => inner,
                     })
-                } else {
-                    SimpleExpr::Interm(Box::new(numerator))
                 };
 
-                let denominator = if !denominator.is_scripted() {
+                let denominator = if denominator.is_scripted() {
+                    SimpleExpr::Interm(Box::new(denominator))
+                } else {
                     denominator.into_interm_with(|inner| match inner {
                         SimpleExpr::Grouping(grp) => {
                             SimpleExpr::Grouping(grp.ignored_parentheses())
                         }
                         _ => inner,
                     })
-                } else {
-                    SimpleExpr::Interm(Box::new(denominator))
                 };
 
                 let binary = Binary {

--- a/src/parser/tests/mod.rs
+++ b/src/parser/tests/mod.rs
@@ -64,7 +64,7 @@ impl std::fmt::Display for Snapshot<&Expression> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("Expression {\n")?;
 
-        let val = format!("{}", Snapshot(&self.0.val))
+        let val = format!("{}", Snapshot(&self.0.interm))
             .lines()
             .map(|l| format!("{}{l}", indent(1)))
             .collect::<Vec<_>>()
@@ -121,6 +121,18 @@ impl std::fmt::Display for Snapshot<&SimpleExpr> {
             }
             SimpleExpr::Unary(unary) => f.write_fmt(format_args!("{}", Snapshot(unary))),
             SimpleExpr::Binary(binary) => f.write_fmt(format_args!("{}", Snapshot(binary))),
+            SimpleExpr::Interm(interm) => {
+                f.write_str("Interm {\n")?;
+
+                let val = format!("{}", Snapshot(&**interm))
+                    .lines()
+                    .map(|l| format!("{}{l}", indent(1)))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                f.write_str(&val)?;
+                f.write_str("}\n")
+            }
         }
     }
 }

--- a/src/parser/tests/snapshots/mathemascii__parser__tests__divide.snap
+++ b/src/parser/tests/snapshots/mathemascii__parser__tests__divide.snap
@@ -6,18 +6,8 @@ a/b
 
 Expression {
 | Fraction(
-| | OpenParen
-| | | Expression {
-| | | | Variable("a")
-| | | }
-| | |
-| | CloseParen,
-| | OpenParen
-| | | Expression {
-| | | | Variable("b")
-| | | }
-| | |
-| | CloseParen
+| | Variable("a"),
+| | Variable("b")
 | )
 }
 

--- a/src/parser/tests/snapshots/mathemascii__parser__tests__special_cases__derivatives.snap
+++ b/src/parser/tests/snapshots/mathemascii__parser__tests__special_cases__derivatives.snap
@@ -9,7 +9,7 @@ Expression {
 }
 
 Expression {
-| Other(Prime)
+| Operator(Prime)
 }
 
 Expression {

--- a/src/parser/tests/snapshots/mathemascii__parser__tests__special_cases__derivatives.snap
+++ b/src/parser/tests/snapshots/mathemascii__parser__tests__special_cases__derivatives.snap
@@ -27,18 +27,8 @@ Expression {
 
 Expression {
 | Fraction(
-| | OpenParen
-| | | Expression {
-| | | | Variable("dy")
-| | | }
-| | |
-| | CloseParen,
-| | OpenParen
-| | | Expression {
-| | | | Variable("dx")
-| | | }
-| | |
-| | CloseParen
+| | Variable("dy"),
+| | Variable("dx")
 | )
 }
 

--- a/tests/snapshots/r#mod__complex_subscripts.snap
+++ b/tests/snapshots/r#mod__complex_subscripts.snap
@@ -10,11 +10,6 @@ lim_(N->oo) sum_(i=0)^N
       lim
     </mi>
     <mrow>
-      <mphantom>
-        <mo>
-          {
-        </mo>
-      </mphantom>
       <mi>
         N
       </mi>
@@ -24,11 +19,6 @@ lim_(N->oo) sum_(i=0)^N
       <mi>
         ∞
       </mi>
-      <mphantom>
-        <mo>
-          }
-        </mo>
-      </mphantom>
     </mrow>
   </munder>
   <munderover>
@@ -36,11 +26,6 @@ lim_(N->oo) sum_(i=0)^N
       ∑
     </mo>
     <mrow>
-      <mphantom>
-        <mo>
-          {
-        </mo>
-      </mphantom>
       <mi>
         i
       </mi>
@@ -50,11 +35,6 @@ lim_(N->oo) sum_(i=0)^N
       <mn>
         0
       </mn>
-      <mphantom>
-        <mo>
-          }
-        </mo>
-      </mphantom>
     </mrow>
     <mi>
       N

--- a/tests/snapshots/r#mod__obrace_text.snap
+++ b/tests/snapshots/r#mod__obrace_text.snap
@@ -34,21 +34,9 @@ obrace(1+2+3+4)^("4 terms")
         ⏞
       </mo>
     </mover>
-    <mrow>
-      <mphantom>
-        <mo>
-          {
-        </mo>
-      </mphantom>
-      <mtext>
-        4 terms
-      </mtext>
-      <mphantom>
-        <mo>
-          }
-        </mo>
-      </mphantom>
-    </mrow>
+    <mtext>
+      4 terms
+    </mtext>
   </mover>
 </math>
 

--- a/tests/snapshots/r#mod__ubrace_text.snap
+++ b/tests/snapshots/r#mod__ubrace_text.snap
@@ -34,21 +34,9 @@ ubrace(1+2+3+4)_("4 terms")
         ⏟
       </mo>
     </munder>
-    <mrow>
-      <mphantom>
-        <mo>
-          {
-        </mo>
-      </mphantom>
-      <mtext>
-        4 terms
-      </mtext>
-      <mphantom>
-        <mo>
-          }
-        </mo>
-      </mphantom>
-    </mrow>
+    <mtext>
+      4 terms
+    </mtext>
   </munder>
 </math>
 


### PR DESCRIPTION
In some cases groupings are used to indicate that a certain part of expression should be interpreted as a single term. For example in fractions: `(a + b) / (c + d)`, or when using scripts `x^(n-1)` and so on. 

In such cases, the grouping symbols don't have to be rendered. For example $\frac{a + b}{c + d} \equiv \frac{(a + b)}{(c + d)}$. The same holds for the scripts: $x^{n-1} \equiv x^{(n-1)}$.

This PR solves that problem. Also, some structures are simplified by using `SimpleExpr::Interm` instead of `SimpleExpr::Grouping` with ignored grouping symbols. This makes snapshots somewhat simpler. 

Additionally, block rendering in binary is now supported with `-b, --block` flag. 